### PR TITLE
remove url from Rawnzb struct Source

### DIFF
--- a/newznab/structs.go
+++ b/newznab/structs.go
@@ -148,7 +148,7 @@ type Time struct {
 
 func (t *Time) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	e.EncodeToken(start)
-	e.EncodeToken(xml.CharData([]byte(t.UTC().Format(time.RFC822))))
+	e.EncodeToken(xml.CharData([]byte(t.UTC().Format(time.RFC1123Z))))
 	e.EncodeToken(xml.EndElement{start.Name})
 	return nil
 }

--- a/newznab/structs.go
+++ b/newznab/structs.go
@@ -124,7 +124,7 @@ type RawNZB struct {
 
 	Source struct {
 		URL   string `xml:"url,attr"`
-		Value string `xml:"url,chardata"`
+		Value string `xml:",chardata"`
 	} `xml:"source,omitempty"`
 
 	Date Time `xml:"pubDate,omitempty"`


### PR DESCRIPTION
I had some issues mocking replies, this change allows me to marshal this struct back into xml 